### PR TITLE
Fix detecting authorizers

### DIFF
--- a/candidates/auhtorizers_scanner.go
+++ b/candidates/auhtorizers_scanner.go
@@ -139,10 +139,14 @@ func (s AuthorizerCandidatesScanner) scanTransaction(
 		s.logger.Error().Err(err).Msg("could not get transaction")
 		return NewCandidatesResultError(err)
 	}
+
 	addresses := make(map[flow.Address]struct{}, len(tx.Authorizers))
 	for _, authorizer := range tx.Authorizers {
 		addresses[authorizer] = struct{}{}
 	}
+	addresses[tx.Payer] = struct{}{}
+	addresses[tx.ProposalKey.Address] = struct{}{}
+
 	return NewCandidatesResult(addresses)
 }
 


### PR DESCRIPTION
## Description

Authorizers were not properly picked up. Sometimes the list of authorizers is empty if the Payer is the only signer, so we have to include the payer (and proposer).
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-bacth-scan/blob/main/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 