### PR TITLE
Add optional metrics to grpc client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/onflow/flow-batch-scan
 go 1.19
 
 require (
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onflow/cadence v0.31.3
 	github.com/onflow/flow-go-sdk v0.31.3

--- a/go.sum
+++ b/go.sum
@@ -141,6 +141,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=

--- a/status_reporter.go
+++ b/status_reporter.go
@@ -46,7 +46,7 @@ type DefaultStatusReporter struct {
 	fullScanRunning  prometheus.Gauge
 	fullScanProgress prometheus.Gauge
 
-	prefix string
+	namespace string
 }
 
 type StatusReporterOption = func(*DefaultStatusReporter)
@@ -66,21 +66,21 @@ func WithStartServer(shouldStartServer bool) StatusReporterOption {
 // NewStatusReporter creates a new status reporter that reports the status of the indexer to prometheus.
 // It will start a http server on the given port that exposes the metrics
 // (unless this is disabled for the case where you would want to serve metrics yourself).
-// the prefix is used to prefix all metrics.
+// the namespace is used to namespace all metrics.
 // The status reporter will report:
 // - the incremental block diff (the difference between the last block height handled by the incremental scanner and the current block height)
 // - the incremental block height (the block height last handled by the incremental scanner)
 // - if a full scan is currently running (if it is any data the scanner is tracking is inaccurate)
 // - if a full scan is currently running, the progress of the full scan (from 0 to 1)
 func NewStatusReporter(
-	prefix string,
+	namespace string,
 	logger zerolog.Logger,
 	options ...StatusReporterOption,
 ) *DefaultStatusReporter {
 	r := &DefaultStatusReporter{
 		port:              DefaultStatusReporterPort,
 		shouldStartServer: true,
-		prefix:            prefix,
+		namespace:         namespace,
 	}
 	r.ComponentBase = NewComponentWithStart("reporter", r.start, logger)
 
@@ -92,7 +92,7 @@ func NewStatusReporter(
 }
 
 func (r *DefaultStatusReporter) start(ctx context.Context) {
-	r.initMetrics(r.prefix)
+	r.initMetrics(r.namespace)
 	if !r.shouldStartServer {
 		r.startServerless(ctx)
 		return
@@ -133,25 +133,29 @@ func (r *DefaultStatusReporter) startServerless(ctx context.Context) {
 	r.Finish(ctx.Err())
 }
 
-func (r *DefaultStatusReporter) initMetrics(prefix string) {
+func (r *DefaultStatusReporter) initMetrics(namespace string) {
 	r.incBlockDiff = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: prefix + "_inc_block_diff",
+		Namespace: namespace,
+		Name:      "inc_block_diff",
 		Help: "The block difference between last incremental check." +
 			"If this is to high the incremental scanner will skip to the latest block" +
 			" and a full scan will be StartupDone to catch up.",
 	})
 	r.incBlockHeight = promauto.NewCounter(prometheus.CounterOpts{
-		Name: prefix + "_inc_block_height",
+		Namespace: namespace,
+		Name:      "inc_block_height",
 		Help: "The block height last handled by the incremental scanner. " +
 			"If no batch scanner is running at this moment, all other results are considered accurate at this block height.",
 	})
 	r.fullScanRunning = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: prefix + "_full_scan_running",
-		Help: "If a full scan is currently running. If It is other statistics may not be accurate.",
+		Namespace: namespace,
+		Name:      "full_scan_running",
+		Help:      "If a full scan is currently running. If It is other statistics may not be accurate.",
 	})
 	r.fullScanProgress = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: prefix + "_full_scan_progress",
-		Help: "If a full scan is currently running, this is the progress of the full scan.",
+		Namespace: namespace,
+		Name:      "full_scan_progress",
+		Help:      "If a full scan is currently running, this is the progress of the full scan.",
 	})
 }
 


### PR DESCRIPTION
Closes: #???

## Description

adds the ability to more easily use custom interceptors on the grpc client  and if desired use the prometheus grpc interceptor: https://github.com/grpc-ecosystem/go-grpc-prometheus
______

For contributor use:

- [ ] Targeted PR against `master` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/flow-bacth-scan/blob/main/CONTRIBUTING.md#styleguides).
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 